### PR TITLE
test: Add Mocha test for footer year

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "gulp-file-include": "^2.3.0",
     "gulp-ignore": "^3.0.0",
     "gulp-replace": "^1.1.4",
-    "gulp-watch": "^5.0.1"
+    "gulp-watch": "^5.0.1",
+    "mocha": "^10.2.0",
+    "jsdom": "^24.0.0"
   },
   "name": "aknethstudio",
   "description": "Strona firmowa Akneth Studio",
@@ -157,7 +159,7 @@
   "scripts": {
     "gulp": "gulp",
     "watch": "gulp watch",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "author": "AKNETH Studio",
   "license": "ISC"

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('footer year', function () {
+  it('should set #year text to current year', function () {
+    const html = '<div id="year"></div>';
+    const dom = new JSDOM(html, { runScripts: 'dangerously' });
+    const script = fs.readFileSync(path.join(__dirname, '../public/js/main.js'), 'utf8');
+    dom.window.eval(script);
+    const yearText = dom.window.document.getElementById('year').textContent;
+    assert.strictEqual(yearText, String(new Date().getFullYear()));
+  });
+});


### PR DESCRIPTION
## Summary
- install Mocha and jsdom dev dependencies
- add test for `public/js/main.js` that verifies the footer year
- provide `npm test` script

## Testing
- `npm test` *(fails: mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432eea9c448331882cad92dac1d86e