### PR TITLE
fix: Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Tests & Collect Coverage
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/akneth-studio/akneth.studio/security/code-scanning/3](https://github.com/akneth-studio/akneth.studio/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best way to do this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` and before `on:`), which will apply to all jobs unless overridden. This ensures the workflow only has read access to repository contents, adhering to the principle of least privilege. If any steps require additional permissions (such as uploading checks or interacting with pull requests), those can be added as needed, but for this workflow, `contents: read` is a safe minimal starting point.

**What to change:**  
- In `.github/workflows/test.yml`, add the following lines after the `name:` line and before the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
- No new imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
